### PR TITLE
fix(cli): resolve GitHub contributor mapping to show proper author names instead of Unknown

### DIFF
--- a/apps/cli/src/interfaces/github-types.ts
+++ b/apps/cli/src/interfaces/github-types.ts
@@ -1,4 +1,5 @@
 // GitHub API types - replacing any usage with proper interfaces
+import type { EnhancedCommitData } from './activity';
 
 export interface GitHubUser {
   login: string;
@@ -309,4 +310,5 @@ export interface GitHubEnhancedActivityData {
     topLabels: Array<{ label: string; count: number }>;
   };
   summary: string;
+  enhancedCommitData?: EnhancedCommitData[];
 }

--- a/apps/cli/src/services/github_enhanced.ts
+++ b/apps/cli/src/services/github_enhanced.ts
@@ -641,13 +641,16 @@ export class EnhancedGitHubService {
     // Author statistics
     const authorCounts = new Map<string, number>();
     commits.forEach((commit) => {
-      const commitData = commit as {
-        commit?: { author?: { name?: string }; committer?: { name?: string } };
-      };
+      const enhancedCommit = commit as EnhancedCommitData;
+
+      // Extract author with proper priority: GitHub login > Git author name > Git author email > committer name
       const author =
-        commitData.commit?.author?.name ??
-        commitData.commit?.committer?.name ??
+        enhancedCommit.commit.author?.login ??
+        enhancedCommit.commit.commit?.author?.name ??
+        enhancedCommit.commit.commit?.author?.email ??
+        enhancedCommit.commit.commit?.committer?.name ??
         'Unknown';
+
       authorCounts.set(author, (authorCounts.get(author) ?? 0) + 1);
     });
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ export default [
   js.configs.recommended,
   {
     files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/dist/**', '**/node_modules/**'],
     languageOptions: {
       parser: typescriptParser,
       parserOptions: {
@@ -82,6 +83,8 @@ export default [
       '**/*.js',
       'apps/web/.next/',
       'packages/*/dist/',
+      'apps/cli/dist/',
+      '**/dist/**/*.d.ts',
       'apps/cli/index.ts', // Not in TypeScript project
     ],
   },


### PR DESCRIPTION
## Problem
The GitHub CLI summary output was showing "Unknown" for contributor names in both individual commit displays and the "Top Contributors" section, while the JSON output correctly showed the actual author names.

## Solution
This PR implements a comprehensive fix for the GitHub contributor mapping issue:

### Key Changes:

#### 1. **Fixed Statistics Calculation** ()
- Updated author extraction logic in  method
- Properly prioritizes: GitHub login → Git author name → Git author email → committer name
- Correctly handles  structure instead of generic commit objects

#### 2. **Fixed Individual Commit Display** ()
- Added proper data conversion from  to 
- Extracts  from  for correct type compatibility
- Maintains PR associations through  property
- Applied consistent author extraction logic for display formatting

#### 3. **Enhanced Type Safety** ()
- Added  property to maintain full context for PR associations
- Proper type imports to resolve compilation warnings

#### 4. **Fixed ESLint Configuration** ()
- Added proper ignore patterns for dist directory to prevent parsing compiled .d.ts files

## Results
✅ **Individual commits**: Now display `by pasevin on [date]` instead of "Unknown"
✅ **Top Contributors**: Shows `pasevin: 9 commits` instead of "Unknown: 9 commits"  
✅ **JSON format**: Continues to work perfectly (no regressions)
✅ **PR associations**: Maintained correctly in commit display
✅ **Type safety**: All TypeScript compilation and linting errors resolved

## Testing
- [x] Verified fix works in both repository and user activity modes
- [x] Confirmed JSON output remains unchanged
- [x] Tested PR associations are preserved
- [x] All linting and type checking passes

Fixes the core issue identified in the GitHub contributor mapping specification.